### PR TITLE
Remove porcelain

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,1 @@
 import Config
-
-config :porcelain, driver: Porcelain.Driver.Basic

--- a/lib/vsntool.ex
+++ b/lib/vsntool.ex
@@ -207,8 +207,7 @@ defmodule Vsntool do
     hookfile = Path.join([File.cwd!(), ".vsntool/hooks", name])
 
     if File.exists?(hookfile) do
-      stream = IO.binstream(:standard_io, :line)
-      %{status: exitcode} = Porcelain.exec(hookfile, args, out: stream)
+      {_, exitcode} = System.cmd(hookfile, args, into: IO.stream())
 
       if exitcode != 0 do
         flunk("#{name} hook exited with code #{exitcode}")

--- a/mix.exs
+++ b/mix.exs
@@ -27,8 +27,7 @@ defmodule Vsntool.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:jason, "~> 1.0"},
-      {:porcelain, "~> 2.0"}
+      {:jason, "~> 1.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,3 @@
 %{
-  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "fdf843bca858203ae1de16da2ee206f53416bbda5dc8c9e78f43243de4bc3afe"},
-  "porcelain": {:hex, :porcelain, "2.0.3", "2d77b17d1f21fed875b8c5ecba72a01533db2013bd2e5e62c6d286c029150fdc", [:mix], [], "hexpm", "dc996ab8fadbc09912c787c7ab8673065e50ea1a6245177b0c24569013d23620"},
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "fdf843bca858203ae1de16da2ee206f53416bbda5dc8c9e78f43243de4bc3afe"}
 }


### PR DESCRIPTION
Kept giving warnings about `goon` missing, polluting the output and thereby the functionality of the tool.

Feature request: allow trailing newlines in VERSION file. Most editors automatically add it (otherwise it's not a "valid unix file', strictly speaking).